### PR TITLE
Fix building conan pkg from source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,20 @@
-## Release 0.2.0 (in progress)
+# Changelog
 
-## Release 0.1.0 (2022-06-28)
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Fixed:
+
+- Building conan pkg from source, [PR-2](https://github.com/panda-official/DriftProtocol/pull/2)
+
+
+
+## 0.1.0 - 2022-06-28
 
 ### Added
 
-* DRIFT-492: Port to Github, [PR-1](https://github.com/panda-official/DriftProtocol/pull/1)
+- DRIFT-492: Port to Github, [PR-1](https://github.com/panda-official/DriftProtocol/pull/1)

--- a/cpp/conanfile.py
+++ b/cpp/conanfile.py
@@ -32,19 +32,20 @@ class DriftFrameworkConan(ConanFile):
         local_source = os.getenv("CONAN_SOURCE_DIR")
         if local_source is not None:
             self.run(
-                "cp %s -r %s" % (os.getenv("CONAN_SOURCE_DIR"), self.source_folder)
+                "cp %s -r %s"
+                % (os.getenv("CONAN_SOURCE_DIR"), f"{self.source_folder}/{self.name}")
             )
         else:
             branch = f"v{self.version}" if self.channel == "stable" else self.channel
             self.run(
                 f"git clone --branch={branch}"
-                " https://github.com/panda-official/DriftProtocol.git drift_protocol"
+                f" https://github.com/panda-official/DriftProtocol.git {self.name}"
             )
 
     def build(self):
         cmake = CMake(self)
         self.run(
-            "cmake -DCMAKE_BUILD_TYPE=Release %s/cpp  %s"
+            "cmake -DCMAKE_BUILD_TYPE=Release %s/drift_protocol/cpp  %s"
             % (self.source_folder, cmake.command_line)
         )
         self.run("cmake --build . -- -j")


### PR DESCRIPTION

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

Conan package couldn't be built from source:

```
CMake Error: The source directory "/home/atimin/.conan/data/drift_protocol/0.2.0-b.2576187115/drift/develop/build/82b48852392ca112918cfe2d48d75f33262ebdc9/cpp" does not exist.
Specify --help for usage, or press the help button on the CMake GUI.
drift_protocol/0.2.0-b.2576187115@drift/develop: 
drift_protocol/0.2.0-b.2576187115@drift/develop: WARN: Package binary is corrupted, removing: 82b48852392ca112918cfe2d48d75f33262ebdc9
drift_protocol/0.2.0-b.2576187115@drift/develop: WARN: Build folder is dirty, removing it: /home/atimin/.conan/data/drift_protocol/0.2.0-b.2576187115/drift/develop/build/82b48852392ca112918cfe2d48d75f33262ebdc9
drift_protocol/0.2.0-b.2576187115@drift/develop: ERROR: Package '82b48852392ca112918cfe2d48d75f33262ebdc9' build failed
drift_protocol/0.2.0-b.2576187115@drift/develop: WARN: Build folder /home/atimin/.conan/data/drift_protocol/0.2.0-b.2576187115/drift/develop/build/82b48852392ca112918cfe2d48d75f33262ebdc9
ERROR: drift_protocol/0.2.0-b.2576187115@drift/develop: Error in build() method, line 46
```

### What is the new behavior?

I fixed directory path

### Does this PR introduce a breaking change?** 

Not

### Other information:
