### PR TITLE
DRIFT-528: Extend meta information about time series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added:
+
+- DRIFT-528: statistic information about time series, [PR-6](https://github.com/panda-official/DriftProtocol/pull/6)  
+
 ## 0.2.0 - 2022-08-23
 
 ### Fixed:

--- a/proto_specs/drift_protocol/meta/meta_info.proto
+++ b/proto_specs/drift_protocol/meta/meta_info.proto
@@ -29,6 +29,11 @@ message TimeSeriesInfo {
   google.protobuf.Timestamp start_timestamp = 1;  // timestamp of the first point in the series
   google.protobuf.Timestamp stop_timestamp = 2;   // timestamp of the last point in the series
   uint64 size = 3;                                // full size of the signal (all DataPayloads together)
+  float first = 4;                                // first value in series
+  float last = 5;                                 // last value in series
+  float min = 6;                                  // min value in series
+  float max = 7;                                  // max value in series
+  float mean = 8;                                 // mean
 }
 
 message ImageInfo {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature

### What is the current behavior?

We send only information about the time interval and size in `TimeSeriesInfo`

### What is the new behavior?

We add statistic information about the series: first, last, min, max and mean values.


### Does this PR introduce a breaking change?** 

No

### Other information:
