### PR TITLE
Add information about wavelet transformation and compression into Drfit Meta

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
             dep_install_cmd: ""
             conan_tail: ""
           - arch: armv8
-            dep_install_cmd: "sudo apt-get update && apt-get install g++-aarch64-linux-gnu"
+            dep_install_cmd: "sudo apt-get update && sudo apt-get install g++-aarch64-linux-gnu"
             conan_tail: "-pr:b=default -pr:h=./linux_armv8 -tf=None"
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
             dep_install_cmd: ""
             conan_tail: ""
           - arch: armv8
-            dep_install_cmd: "sudo apt-get install g++-aarch64-linux-gnu"
+            dep_install_cmd: "sudo apt-get update && apt-get install g++-aarch64-linux-gnu"
             conan_tail: "-pr:b=default -pr:h=./linux_armv8 -tf=None"
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- DRIFT-680: Add information about wavelet transformation and compression into Drfit
+  Meta, [PR-15](https://github.com/panda-official/DriftProtocol/pull/15)
+
 ## 0.4.0 - 2023-05-17
 
 ### Added
 
-- DRIFT-617: Conan packgae compilation for armv8, conan test_package [PR-11](https://github.com/panda-official/DriftProtocol/pull/11/)
+- DRIFT-617: Conan packgae compilation for armv8, conan
+  test_package [PR-11](https://github.com/panda-official/DriftProtocol/pull/11/)
 - Labels, [PR-17](https://github.com/panda-official/DriftProtocol/pull/17)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-### 0.4.0 - 2023-05-17
+## 0.4.0 - 2023-05-17
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The Drift Protocol is a set of libraries that
 use [Protocol Buffers](https://developers.google.com/protocol-buffers/docs/overview) (Protobuf) to encode messages in
-the [PANDA|Drift infrastructure](https://driftpythonclient.readthedocs.io/en/latest/docs/panda_drift/).. The libraries
+the [PANDA|Drift infrastructure](https://driftpythonclient.readthedocs.io/en/latest/docs/panda_drift/). The libraries
 provide pre-generated Protobuf messages so that users do not have to install the protobuf compiler and generate them
 themselves.
 
@@ -18,26 +18,26 @@ accompanying diagram:
 
 ![Drift Protocol Example](docs/img/example.drawio.svg)
 
-Trigger Service publishes a trigger as a [Drift Package](docs/api/common.md#driftpackage) with ID = 1630062869443 and
+The Trigger service publishes a trigger as a [Drift Package](docs/api/common.md#driftpackage) with ID = 1630062869443 and
 a [Trigger Interval Message](docs/api/triggering.md#intervaltriggermessage), which contains a time interval [t0, t1], to
 the  `trigger` MQTT topic.
 
-Timeswipe Service subscribes on the `trigger` topic and receives the trigger package. Then it retrieves data of 48000
-samples per second from a vibration sensor for the interval [t0, t1] by using Time Swipe Device, compresses, serializes
+The Timeswipe service subscribes to the `trigger` topic and receives a trigger package. Then it retrieves data of 48000
+samples per second from a vibration sensor for the interval [t0, t1] by using a Time Swipe device, compresses, serializes
 the data and sends it to MQTT topic `drift/sensor` as a [Drift Package](docs/api/common.md#driftpackage) with
 a [Data Payload](docs/api/common.md#datapayload) inside. It contains a
 serialized [Wavelet Buffer](https://github.com/panda-official/WaveletBuffer) in the `data` field. The ID of the packages
 is the same ID=1630062869443, so we see that the trigger and the data are connected.
 
 The [Drift Core](https://driftpythonclient.readthedocs.io/en/latest/docs/panda_drift/) services subscribe to all MQTT
-topics which have `drift/` prefix, parse [Drift Packages](docs/api/common.md#driftpackage) and store them in the metric
+topics which have `drift/` prefix, parse [Drift Packages](docs/api/common.md#driftpackage) and stores them in the metric
 and blob storages. After that, you can use [Drift Python Client](https://github.com/panda-official/DriftPythonClient) to
 request data from the storage.
 
 ## Why Protobuf?
 
 We use Protobuf to encode messages in Drift Protocol because it is a very efficient and flexible serialization format,
-especially for binary data. It is also very easy to use and has a lot of implementations for different programming
+especially for binary data. It is also very easy to use and has a lot of implementations for different programming languages.
 
 ## Related Projects
 

--- a/docs/api/meta.md
+++ b/docs/api/meta.md
@@ -94,15 +94,15 @@ different MQTT topics.
 
 WaveletBufferInfo describes a wavelet transformation and compression parameters if they were applied to the data.
 
-| Name                | Type                                   | Description                                                                                      |
-|---------------------|----------------------------------------|--------------------------------------------------------------------------------------------------|
-| abi_version         | uint32                                 | ABI version of the WaveletBuffer library                                                         |
-| wavelet_type        | uint32                                 | Wavelet type 0-no wavelet transformation, 1-DB1, 2-DB2 etc.                                      |
-| decomposition_steps | uint32                                 | Number of decomposition steps applied to the data                                                |
-| compression_level   | uint32                                 | Compression level applied to the data, 0 - no compression, 1-float is 2bit, 2-float is 3bit etc. |
-| no_denoising        | [MetaInfo](meta.md#nodenoising)        | If initialized, no denoising was applied to the data.                                            |
-| threshold_denoising | [MetaInfo](meta.md#thresholddenoising) | If initialized, threshold denoising was applied to the data.                                     |
-| partial_denoising   | [MetaInfo](meta.md#partialdenoising)   | If initialized, partial denoising was applied to the data.                                       |
+| Name                | Type                                             | Description                                                                                      |
+|---------------------|--------------------------------------------------|--------------------------------------------------------------------------------------------------|
+| abi_version         | uint32                                           | ABI version of the WaveletBuffer library                                                         |
+| wavelet_type        | uint32                                           | Wavelet type 0-no wavelet transformation, 1-DB1, 2-DB2 etc.                                      |
+| decomposition_steps | uint32                                           | Number of decomposition steps applied to the data                                                |
+| compression_level   | uint32                                           | Compression level applied to the data, 0 - no compression, 1-float is 2bit, 2-float is 3bit etc. |
+| no_denoising        | [NoDenoising](meta.md#nodenoising)               | If initialized, no denoising was applied to the data.                                            |
+| threshold_denoising | [ThresholdDenoising](meta.md#thresholddenoising) | If initialized, threshold denoising was applied to the data.                                     |
+| partial_denoising   | [PartialDenoising](meta.md#partialdenoising)     | If initialized, partial denoising was applied to the data.                                       |
 
 ## NoDenoising
 

--- a/docs/api/meta.md
+++ b/docs/api/meta.md
@@ -27,6 +27,7 @@ Top-level descriptor which has type of data in Drift Package and a type specific
 | scalar_info         | [ScalarValuesInfo](meta.md#scalarvaluesinfo)                             |                                                                                  |
 | text_info           | [TextInfo](meta.md#textinfo)                                             |                                                                                  |
 | alignment_info      | [AlignmentInfo](meta.md#alignmentinfo)                                   |                                                                                  |
+| wavelet_buffer_info | [WaveletBufferInfo](meta.md#waveletbufferinfo)                           | Information about wavelet transformation and compression if used                 |
 
 ## TimeSeriesInfo
 
@@ -88,3 +89,43 @@ different MQTT topics.
 | **PackageInfo** |                              |                                                           |
 | topic           | string                       | Name of source topic                                      |
 | meta            | [MetaInfo](meta.md#metainfo) | Meta information for the package                          |
+
+## WaveletBufferInfo
+
+WaveletBufferInfo describes a wavelet transformation and compression parameters if they were applied to the data.
+
+| Name                | Type                                   | Description                                                                                      |
+|---------------------|----------------------------------------|--------------------------------------------------------------------------------------------------|
+| abi_version         | uint32                                 | ABI version of the WaveletBuffer library                                                         |
+| wavelet_type        | uint32                                 | Wavelet type 0-no wavelet transformation, 1-DB1, 2-DB2 etc.                                      |
+| decomposition_steps | uint32                                 | Number of decomposition steps applied to the data                                                |
+| compression_level   | uint32                                 | Compression level applied to the data, 0 - no compression, 1-float is 2bit, 2-float is 3bit etc. |
+| no_denoising        | [MetaInfo](meta.md#nodenoising)        | If initialized, no denoising was applied to the data.                                            |
+| threshold_denoising | [MetaInfo](meta.md#thresholddenoising) | If initialized, threshold denoising was applied to the data.                                     |
+| partial_denoising   | [MetaInfo](meta.md#partialdenoising)   | If initialized, partial denoising was applied to the data.                                       |
+
+## NoDenoising
+
+No denoising was applied to the data.
+
+| Name | Type | Description |
+|------|------|-------------|
+
+## ThresholdDenoising
+
+A denoising method that uses a threshold to remove small coefficients. The threshold is calculated as a linear function
+a*x+b,
+where x is the step of decomposition.
+
+| Name | Type  | Description |
+|------|-------|-------------|
+| a    | float | float       |  
+| b    | float | float       |
+
+## PartialDenoising
+
+A denoising method that removes a part of coefficients
+
+| Name    | Type  | Description                                          |
+|---------|-------|------------------------------------------------------|
+| partial | float | part of coefficients to remove 1.0 - all, 0.0 - none |

--- a/docs/cpp_examples/drift_package_example.md
+++ b/docs/cpp_examples/drift_package_example.md
@@ -3,5 +3,5 @@
 This example shows how to serialize and parse a [Drift Package](../api/common.md) in C++.
 
 ```cpp title="cpp/examples/drift_package_example.cc"
---8<-- "../cpp/examples/drift_package_example.cc:"
+--8<--"../cpp/examples/drift_package_example.cc"
 ```

--- a/docs/cpp_examples/payload_with_image_example.md
+++ b/docs/cpp_examples/payload_with_image_example.md
@@ -5,5 +5,5 @@ with [WaveletBuffer](https://github.com/panda-official/WaveletBuffer) and build 
 [meta information](../api/meta.md) in C++.
 
 ```cpp title="cpp/examples/payload_with_image_example.cc"
---8<-- "../cpp/examples/payload_with_image_example.cc"
+--8<--"../cpp/examples/payload_with_image_example.cc"
 ```

--- a/docs/cpp_examples/payload_with_scalars_example.md
+++ b/docs/cpp_examples/payload_with_scalars_example.md
@@ -4,5 +4,5 @@ Here you can see how to compress scalar values data with [WaveletBuffer](https:/
 and build a [Drift Package](../api/common.md) with [meta information](../api/meta.md) in C++.
 
 ```cpp title="cpp/examples/payload_with_scalars.cc"
---8<-- "../cpp/examples/payload_with_scalars.cc"
+--8<--"../cpp/examples/payload_with_scalars.cc"
 ```

--- a/docs/cpp_examples/payload_with_timeseries_example.md
+++ b/docs/cpp_examples/payload_with_timeseries_example.md
@@ -4,5 +4,5 @@ Here you can see how to compress time series data with [WaveletBuffer](https://g
 and build a [Drift Package](../api/common.md) with [meta information](../api/meta.md) in C++.
 
 ```cpp title="cpp/examples/payload_with_timeseries_example.cc"
---8<-- "../cpp/examples/payload_with_timeseries_example.cc"
+--8<--"../cpp/examples/payload_with_timeseries_example.cc"
 ```

--- a/docs/cpp_examples/trigger_message_example.md
+++ b/docs/cpp_examples/trigger_message_example.md
@@ -4,5 +4,5 @@ Here you can see how to build a [Drift Package](../api/common.md) with [a trigge
 time interval in C++.
 
 ```cpp title="cpp/examples/trigger_message_example.cc"
---8<-- "../cpp/examples/trigger_message_example.cc"
+--8<--"../cpp/examples/trigger_message_example.cc"
 ```

--- a/docs/py_examples/drift_package_example.md
+++ b/docs/py_examples/drift_package_example.md
@@ -3,5 +3,5 @@
 This example shows how to serialize and parse a [Drift Package](../api/common.md) in Python.
 
 ```py title="python/examples/drift_package_example.py"
---8<-- "../python/examples/drift_package_example.py:"
+--8<--"../python/examples/drift_package_example.py:"
 ```

--- a/docs/py_examples/payload_with_image_example.md
+++ b/docs/py_examples/payload_with_image_example.md
@@ -5,5 +5,5 @@ with [WaveletBuffer](https://github.com/panda-official/WaveletBuffer) and build 
 [meta information](../api/meta.md) in Python.
 
 ```py title="python/examples/payload_with_image_example.py"
---8<-- "../python/examples/payload_with_image_example.py"
+--8<--"../python/examples/payload_with_image_example.py"
 ```

--- a/docs/py_examples/payload_with_scalars_example.md
+++ b/docs/py_examples/payload_with_scalars_example.md
@@ -4,5 +4,5 @@ Here you can see how to compress scalar values data with [WaveletBuffer](https:/
 and build a [Drift Package](../api/common.md) with [meta information](../api/meta.md) in Python.
 
 ```py title="python/examples/payload_with_scalars.py"
---8<-- "../python/examples/payload_with_scalars.py"
+--8<-- ../python/examples/payload_with_scalars.py"
 ```

--- a/docs/py_examples/payload_with_timeseries_example.md
+++ b/docs/py_examples/payload_with_timeseries_example.md
@@ -4,5 +4,5 @@ Here you can see how to compress time series data with [WaveletBuffer](https://g
 and build a [Drift Package](../api/common.md) with [meta information](../api/meta.md) in Python.
 
 ```py title="python/examples/payload_with_timeseries_example.py"
---8<-- "../python/examples/payload_with_timeseries_example.py"
+--8<--"../python/examples/payload_with_timeseries_example.py"
 ```

--- a/docs/py_examples/trigger_message_example.md
+++ b/docs/py_examples/trigger_message_example.md
@@ -4,5 +4,5 @@ Here you can see how to build a [Drift Package](../api/common.md) with [a trigge
 time interval in Python.
 
 ```py title="python/examples/trigger_message_example.py"
---8<-- "../python/examples/trigger_message_example.py"
+--8<--"../python/examples/trigger_message_example.py"
 ```

--- a/proto_specs/drift_protocol/meta/meta_info.proto
+++ b/proto_specs/drift_protocol/meta/meta_info.proto
@@ -9,7 +9,7 @@ import "drift_protocol/common/status_code.proto";
 message MetaInfo {
   DataType type = 1;
 
-  oneof info {  // type specific structures
+  oneof info {// type specific structures
     TimeSeriesInfo time_series_info = 2;
     ImageInfo image_info = 3;
     ScalarValuesInfo scalar_info = 4;
@@ -23,6 +23,34 @@ message MetaInfo {
     SCALAR_VALUES = 2;
     TEXT = 3;
     ALIGNED_PACKAGE = 4;
+  }
+}
+
+message WaveletBufferInfo {
+  message NoDenoising {
+  }
+
+  // ThresholdDenoising is a denoising method that uses a threshold to remove
+  // small coefficients. The threshold is calculated as a linear function a*x+b,
+  // where x is the step of decomposition.
+  message ThresholdDenoising {
+    float a = 1;
+    float b = 2;
+  }
+
+  // PartialDenoising is a denoising method that removes a part of coefficients
+  message PartialDenoising {
+    float partial = 1; /// part of coefficients to remove 1.0 - all, 0.0 - none
+  }
+
+  uint32 abi_version = 1;  // version of compression algorithm
+  uint32 wavelet_type = 2;  // type of wavelet used for compression
+  uint32 decomposition_steps = 3;  // number of decomposition steps
+  uint32 compression_level = 4;  // compression level
+  oneof denoising {
+    NoDenoising no_denoising = 5;
+    ThresholdDenoising threshold_denoising = 6;
+    PartialDenoising partial_denoising = 7;
   }
 }
 

--- a/proto_specs/drift_protocol/meta/meta_info.proto
+++ b/proto_specs/drift_protocol/meta/meta_info.proto
@@ -5,26 +5,6 @@ package drift.proto.meta;
 import "google/protobuf/timestamp.proto";
 import "drift_protocol/common/status_code.proto";
 
-// Descriptor of data in DriftPackage
-message MetaInfo {
-  DataType type = 1;
-
-  oneof info {// type specific structures
-    TimeSeriesInfo time_series_info = 2;
-    ImageInfo image_info = 3;
-    ScalarValuesInfo scalar_info = 4;
-    TextInfo text_info = 5;
-    AlignmentInfo alignment_info = 6;
-  }
-
-  enum DataType {
-    TIME_SERIES = 0;
-    IMAGE = 1;
-    SCALAR_VALUES = 2;
-    TEXT = 3;
-    ALIGNED_PACKAGE = 4;
-  }
-}
 
 message WaveletBufferInfo {
   message NoDenoising {
@@ -48,10 +28,34 @@ message WaveletBufferInfo {
   uint32 decomposition_steps = 3;  // number of decomposition steps
   uint32 compression_level = 4;  // compression level
   oneof denoising {
-    NoDenoising no_denoising = 5;
-    ThresholdDenoising threshold_denoising = 6;
-    PartialDenoising partial_denoising = 7;
+    NoDenoising no_denoising = 15;
+    ThresholdDenoising threshold_denoising = 16;
+    PartialDenoising partial_denoising = 17;
   }
+}
+
+
+// Descriptor of data in DriftPackage
+message MetaInfo {
+  enum DataType {
+    TIME_SERIES = 0;
+    IMAGE = 1;
+    SCALAR_VALUES = 2;
+    TEXT = 3;
+    ALIGNED_PACKAGE = 4;
+  }
+
+  DataType type = 1;
+
+  oneof info {// type specific structures
+    TimeSeriesInfo time_series_info = 2;
+    ImageInfo image_info = 3;
+    ScalarValuesInfo scalar_info = 4;
+    TextInfo text_info = 5;
+    AlignmentInfo alignment_info = 6;
+  }
+
+  WaveletBufferInfo wavelet_buffer_info = 7; // info about wavelet transformation and compression if used
 }
 
 message TimeSeriesInfo {


### PR DESCRIPTION
**Closes** #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature

### What is the current behavior?

For many applications, where we denoise data and it's important to know the parameters of the denoising.
However, Drift packages don't provide this information.


### What is the new behavior?

We add denoising information into Meta Protocol for Images and Timeseries


### Does this PR introduce a breaking change?

No

### Other information:
