### PR TITLE
Add support for typed data in Datapayload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- TypedDataInfo to send typed data in DataPayload, [PR-18](https://github.com/panda-official/DriftProtocol/pull/18)
+
 ## 0.5.0 - 2023-06-15
 
 ### Added

--- a/docs/api/common.md
+++ b/docs/api/common.md
@@ -20,7 +20,8 @@ it, so that the PANDA|Drift infrastructure can handle and store them.
 ## DataPayload
 
 DataPayload represents serialized data which a server sends via MQTT. It is usually data denoised and compressed by
-using [WaveletBuffer](https://github.com/panda-official/WaveletBuffer).
+using [WaveletBuffer](https://github.com/panda-official/WaveletBuffer), or it can be serialized data in little-endian format.
+In case if it is the serialized data, the layout of the data is described by [MetaProtocol](meta.md#typeddatainfo))
 
 | Name  | Type   | Description                                                                                                                                                             |
 |-------|--------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/docs/api/meta.md
+++ b/docs/api/meta.md
@@ -13,6 +13,7 @@ The meta information describes the following data types:
 * Scala Values
 * Text
 * Aligned Data
+* Typed Data
 
 ## MetaInfo
 
@@ -27,6 +28,7 @@ Top-level descriptor which has type of data in Drift Package and a type specific
 | scalar_info         | [ScalarValuesInfo](meta.md#scalarvaluesinfo)                             |                                                                                  |
 | text_info           | [TextInfo](meta.md#textinfo)                                             |                                                                                  |
 | alignment_info      | [AlignmentInfo](meta.md#alignmentinfo)                                   |                                                                                  |
+| typed_data_info     | [TypedDataInfo](meta.md#typeddatainfo)                                   |                                                                                  |
 | wavelet_buffer_info | [WaveletBufferInfo](meta.md#waveletbufferinfo)                           | Information about wavelet transformation and compression if used                 |
 
 ## TimeSeriesInfo
@@ -63,6 +65,8 @@ ScalarValuesInfo describes scalar values inside DriftPackage which is sent
 as a [WaveletBuffer](https://github.com/panda-official/WaveletBuffer) without any decomposition.
 This type of data is used when we have some samples as intentioned parameters from a data source.
 
+DEPRECATED: use [TypedDataInfo](meta.md#typeddatainfo) instead.
+
 | Name          | Type                               | Description                                        |
 |---------------|------------------------------------|----------------------------------------------------|
 | variables     | ValueInfo[]                        | Description for each scalar value in WaveletBuffer |
@@ -89,6 +93,38 @@ different MQTT topics.
 | **PackageInfo** |                              |                                                           |
 | topic           | string                       | Name of source topic                                      |
 | meta            | [MetaInfo](meta.md#metainfo) | Meta information for the package                          |
+
+## TypedDataInfo
+
+TypedDataInfo describes how to parse a binary data inside [DataPayload](common.md) when the data has values of different
+types (not only float).
+
+| Name     | Type     | Description                              |
+|----------|----------|------------------------------------------|
+| items    | Item[]   | Description for each item in DataPayload |
+| **Item** |          |                                          |
+| name     | string   | Name of item                             |
+| type     | Type     | Type of item                             |
+| status   | Status   | Status of item                           |
+| shape    | uint64[] | Shape of item                            |
+
+Supported types:
+
+| Name    | ID | Description             |
+|---------|----|-------------------------|
+| BOOL    | 0  | Boolean                 |
+| INT8    | 1  | 8-bit signed integer    |
+| UINT8   | 2  | 8-bit unsigned integer  |
+| INT16   | 3  | 16-bit signed integer   |
+| UINT16  | 4  | 16-bit unsigned integer |
+| INT32   | 5  | 32-bit signed integer   |
+| UINT32  | 6  | 32-bit unsigned integer |
+| INT64   | 7  | 64-bit signed integer   |
+| UINT64  | 8  | 64-bit unsigned integer |
+| FLOAT32 | 9  | 32-bit float            |
+| FLOAT64 | 10 | 64-bit float            |
+| STRING  | 11 | UTF-8 String            |
+
 
 ## WaveletBufferInfo
 

--- a/docs/api/meta.md
+++ b/docs/api/meta.md
@@ -10,7 +10,7 @@ The meta information describes the following data types:
 
 * Time Series
 * Images
-* Scala Values
+* Scalar Values (deprecated)
 * Text
 * Aligned Data
 * Typed Data

--- a/proto_specs/drift_protocol/meta/meta_info.proto
+++ b/proto_specs/drift_protocol/meta/meta_info.proto
@@ -83,6 +83,7 @@ message ImageInfo {
   }
 }
 
+// Deprecated
 message ScalarValuesInfo {
   repeated VariableInfo variables = 1; // FIXME: ??? not sure variables is a good name
   message VariableInfo {
@@ -104,23 +105,27 @@ message AlignmentInfo {
 }
 
 message TypedDataInfo {
-  enum Type {
-    BOOL = 0;
-    INT8 = 1;
-    UINT8 = 2;
-    INT16 = 3;
-    UINT16 = 4;
-    INT32 = 5;
-    UINT32 = 6;
-    INT64 = 7;
-    UINT64 = 8;
-    FLOAT32 = 9;
-    FLOAT64 = 10;
-    STRING = 11;
-  };
+  message Item {
+    enum Type {
+      BOOL = 0;
+      INT8 = 1;
+      UINT8 = 2;
+      INT16 = 3;
+      UINT16 = 4;
+      INT32 = 5;
+      UINT32 = 6;
+      INT64 = 7;
+      UINT64 = 8;
+      FLOAT32 = 9;
+      FLOAT64 = 10;
+      STRING = 11;
+    };
 
-  string name = 1; // name of data
-  common.StatusCode status = 2; // status of data
-  Type type = 3; // type of data
-  repeated uint64 shape = 4; // shape of data
+    string name = 1; // name of data
+    common.StatusCode status = 2; // status of data
+    Type type = 3; // type of data
+    repeated uint64 shape = 4; // shape of data
+  }
+
+  repeated Item items = 1;
 }

--- a/proto_specs/drift_protocol/meta/meta_info.proto
+++ b/proto_specs/drift_protocol/meta/meta_info.proto
@@ -43,6 +43,7 @@ message MetaInfo {
     SCALAR_VALUES = 2;
     TEXT = 3;
     ALIGNED_PACKAGE = 4;
+    TYPED_DATA = 5;
   }
 
   DataType type = 1;
@@ -53,6 +54,7 @@ message MetaInfo {
     ScalarValuesInfo scalar_info = 4;
     TextInfo text_info = 5;
     AlignmentInfo alignment_info = 6;
+    TypedDataInfo typed_data_info = 8;
   }
 
   WaveletBufferInfo wavelet_buffer_info = 7; // info about wavelet transformation and compression if used
@@ -99,4 +101,26 @@ message AlignmentInfo {
     string topic = 1;   // name of source  MQTT topic
     MetaInfo meta = 2;  // meta information
   }
+}
+
+message TypedDataInfo {
+  enum Type {
+    BOOL = 0;
+    INT8 = 1;
+    UINT8 = 2;
+    INT16 = 3;
+    UINT16 = 4;
+    INT32 = 5;
+    UINT32 = 6;
+    INT64 = 7;
+    UINT64 = 8;
+    FLOAT32 = 9;
+    FLOAT64 = 10;
+    STRING = 11;
+  };
+
+  string name = 1; // name of data
+  common.StatusCode status = 2; // status of data
+  Type type = 3; // type of data
+  repeated uint64 shape = 4; // shape of data
 }


### PR DESCRIPTION
**Closes** #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature

### What is the current behavior?

Currently, we can send only floats for scalar values because we use `WaveletBuffer` as a container. It doesn't work for flags, strings or big integers.

### What is the new behavior?

In this PR, we introduce the TypedDataInfo structure in Meta Protocol, which can be used to decode serialized values in DataPayload for the following types:


| Name    | ID | Description             |
|---------|----|-------------------------|
| BOOL    | 0  | Boolean                 |
| INT8    | 1  | 8-bit signed integer    |
| UINT8   | 2  | 8-bit unsigned integer  |
| INT16   | 3  | 16-bit signed integer   |
| UINT16  | 4  | 16-bit unsigned integer |
| INT32   | 5  | 32-bit signed integer   |
| UINT32  | 6  | 32-bit unsigned integer |
| INT64   | 7  | 64-bit signed integer   |
| UINT64  | 8  | 64-bit unsigned integer |
| FLOAT32 | 9  | 32-bit float            |
| FLOAT64 | 10 | 64-bit float            |
| STRING  | 11 | UTF-8 String            |

### Does this PR introduce a breaking change?

(What changes might users need to make in their application due to this PR?)

### Other information:
